### PR TITLE
Fix private storage migrations

### DIFF
--- a/contentfiles/storage.py
+++ b/contentfiles/storage.py
@@ -3,9 +3,9 @@ from __future__ import unicode_literals
 import os
 
 from django.conf import settings
-from django.core.files.storage import get_storage_class
-from django.utils.functional import LazyObject
+from django.core.files.storage import DefaultStorage
 from django.utils.six.moves import urllib
+
 from storages.backends.s3boto import S3BotoStorage
 
 
@@ -36,17 +36,20 @@ class MediaStorage(BaseContentFilesStorage):
             protocol, hostname, urllib.parse.quote(name.encode('utf-8')))
 
 
-class BasePrivateStorage(BaseContentFilesStorage):
+class RemotePrivateStorage(BaseContentFilesStorage):
     bucket_name = os.environ.get('CONTENTFILES_PRIVATE_BUCKET')
     default_acl = 'private'
     querystring_expire = 300
 
 
-class PrivateStorage(LazyObject):
-    def _setup(self):
-        private_bucket = os.environ.get('CONTENTFILES_PRIVATE_BUCKET')
+if os.environ.get('CONTENTFILES_PRIVATE_BUCKET') is not None:
+    BasePrivateStorage = RemotePrivateStorage
+else:
+    BasePrivateStorage = DefaultStorage
 
-        if private_bucket is not None:
-            self._wrapped = BasePrivateStorage()
-        else:
-            self._wrapped = get_storage_class()()
+
+class PrivateStorage(BasePrivateStorage):
+    pass
+
+
+private_storage = PrivateStorage()


### PR DESCRIPTION
We rarely use this, however it's occasionally needed on projects where we need to protect file uploads from being downloaded too easily.

Before:

```python
# With CONTENTFILES_PRIVATE_BUCKET env var set:
('file', models.FileField(upload_to=core.utils.unique_upload_path, storage=contentfiles.storage.BasePrivateStorage()))

# When unset (local development):
('file', models.FileField(upload_to=core.utils.unique_upload_path, storage=django.core.files.storage.FileSystemStorage()))
```

After:

```python
('file', models.FileField(upload_to=core.utils.unique_upload_path, storage=contentfiles.storage.PrivateStorage()))
```
