### PR TITLE
Swap quote for filepath_to_uri

### DIFF
--- a/contentfiles/storage.py
+++ b/contentfiles/storage.py
@@ -4,7 +4,7 @@ import os
 
 from django.conf import settings
 from django.core.files.storage import DefaultStorage
-from django.utils.six.moves import urllib
+from django.utils.encoding import filepath_to_uri
 
 from boto.s3.connection import S3Connection
 from storages.backends.s3boto import S3BotoStorage
@@ -37,7 +37,7 @@ class MediaStorage(BaseContentFilesStorage):
             hostname = CONTENTFILES_HOSTNAME
 
         return '%s://%s/media/%s' % (
-            protocol, hostname, urllib.parse.quote(name.encode('utf-8')))
+            protocol, hostname, filepath_to_uri(name))
 
 
 class RemotePrivateStorage(BaseContentFilesStorage):


### PR DESCRIPTION
filepath_to_uri uses quote under the hood anyway, and can deal with the different Python versions - instead of us having to use django.utils.six

https://github.com/django/django/blob/1.11.29/django/utils/encoding.py#L252

It's also what django-storages uses:

https://github.com/jschneier/django-storages/blob/1.8/storages/backends/s3boto.py#L503

Wanting to get this in before we update all the sites
